### PR TITLE
Fix up versions field in package search details

### DIFF
--- a/dcos/docs/PackageSearchDetails.md
+++ b/dcos/docs/PackageSearchDetails.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **Selected** | **bool** |  | [optional] 
 **Images** | [**Images**](images.md) |  | [optional] 
 **Tags** | **[]string** |  | 
-**Versions** | **[]string** |  | 
+**Versions** | [**map[string]interface{}**](.md) |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/dcos/model_package_search_details.go
+++ b/dcos/model_package_search_details.go
@@ -11,12 +11,12 @@
 package dcos
 
 type PackageSearchDetails struct {
-	Name           string   `json:"name"`
-	CurrentVersion string   `json:"currentVersion"`
-	Description    string   `json:"description"`
-	Framework      bool     `json:"framework"`
-	Selected       bool     `json:"selected,omitempty"`
-	Images         Images   `json:"images,omitempty"`
-	Tags           []string `json:"tags"`
-	Versions       []string `json:"versions"`
+	Name           string                 `json:"name"`
+	CurrentVersion string                 `json:"currentVersion"`
+	Description    string                 `json:"description"`
+	Framework      bool                   `json:"framework"`
+	Selected       bool                   `json:"selected,omitempty"`
+	Images         Images                 `json:"images,omitempty"`
+	Tags           []string               `json:"tags"`
+	Versions       map[string]interface{} `json:"versions"`
 }

--- a/openapi/dcos.yaml
+++ b/openapi/dcos.yaml
@@ -1947,9 +1947,7 @@ components:
             type: string
           type: array
         versions:
-          type: "array"
-          items:
-            type: "string"
+          type: "object"
       required:
         - name
         - currentVersion


### PR DESCRIPTION
The versions field is actually an object mapping from version string to order integer, such as:

```
versions:
  1.0.24-3.0.10: 24
  1.0.23-3.0.10: 23
```