### PR TITLE
let sp-metadata return the body as string

### DIFF
--- a/dcos/api_iam.go
+++ b/dcos/api_iam.go
@@ -2764,7 +2764,7 @@ func (a *IAMApiService) GetSAMLProviderSPMetadata(ctx context.Context, providerI
 	}
 
 	// to determine the Accept header
-	localVarHttpHeaderAccepts := []string{"application/samlmetadata+xml"}
+	localVarHttpHeaderAccepts := []string{"application/samlmetadata+xml", "application/json"}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)

--- a/dcos/api_iam.go
+++ b/dcos/api_iam.go
@@ -2734,14 +2734,16 @@ IAMApiService Get SP metadata (XML).
 The IAM acts as SAML service provider (SP). This endpoint provides the SP metadata as an XML document. Certain identity providers (IdPs) may want to directly consume this document.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param providerId The ID of the SAML provider to retrieve the metadata for.
+@return string
 */
-func (a *IAMApiService) GetSAMLProviderSPMetadata(ctx context.Context, providerId string) (*http.Response, error) {
+func (a *IAMApiService) GetSAMLProviderSPMetadata(ctx context.Context, providerId string) (string, *http.Response, error) {
 	var (
 		localVarHttpMethod   = strings.ToUpper("Get")
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		localVarReturnValue  string
 	)
 
 	// create path and map variables
@@ -2762,7 +2764,7 @@ func (a *IAMApiService) GetSAMLProviderSPMetadata(ctx context.Context, providerI
 	}
 
 	// to determine the Accept header
-	localVarHttpHeaderAccepts := []string{}
+	localVarHttpHeaderAccepts := []string{"application/samlmetadata+xml"}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -2771,18 +2773,18 @@ func (a *IAMApiService) GetSAMLProviderSPMetadata(ctx context.Context, providerI
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return nil, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHttpResponse, err := a.client.callAPI(r)
 	if err != nil || localVarHttpResponse == nil {
-		return localVarHttpResponse, err
+		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
-		return localVarHttpResponse, err
+		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
@@ -2790,10 +2792,29 @@ func (a *IAMApiService) GetSAMLProviderSPMetadata(ctx context.Context, providerI
 			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-		return localVarHttpResponse, newErr
+		if localVarHttpResponse.StatusCode == 200 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
-	return localVarHttpResponse, nil
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHttpResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHttpResponse, nil
 }
 
 /*

--- a/dcos/docs/IAMApi.md
+++ b/dcos/docs/IAMApi.md
@@ -1046,7 +1046,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **GetSAMLProviderSPMetadata**
-> GetSAMLProviderSPMetadata(ctx, providerId)
+> string GetSAMLProviderSPMetadata(ctx, providerId)
 Get SP metadata (XML).
 
 The IAM acts as SAML service provider (SP). This endpoint provides the SP metadata as an XML document. Certain identity providers (IdPs) may want to directly consume this document.
@@ -1060,7 +1060,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+**string**
 
 ### Authorization
 
@@ -1069,7 +1069,7 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: Not defined
+ - **Accept**: application/samlmetadata+xml
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/dcos/docs/IAMApi.md
+++ b/dcos/docs/IAMApi.md
@@ -1069,7 +1069,7 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: application/samlmetadata+xml
+ - **Accept**: application/samlmetadata+xml, application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/openapi/dcos.yaml
+++ b/openapi/dcos.yaml
@@ -948,6 +948,10 @@ paths:
         "200":
           description: The response body contains the metadata in UTF-8 encoding, setting
             the Content-Type to `application/samlmetadata+xml`.
+          content:
+            application/samlmetadata+xml:
+              schema:
+                type: string
   /acs/api/v1/groups:
     get:
       operationId: getGroups

--- a/openapi/dcos.yaml
+++ b/openapi/dcos.yaml
@@ -952,6 +952,10 @@ paths:
             application/samlmetadata+xml:
               schema:
                 type: string
+            application/json:
+              # Workaround mandatory accept application/json (DCOS-53724)
+              schema:
+                type: string
   /acs/api/v1/groups:
     get:
       operationId: getGroups


### PR DESCRIPTION
sp-metadata endpoint was available but did not return the body. Furthermore it closed the `resp.Body`.

This adds the OpenAPI description to return the body as string