### PR TITLE
Address CLI regressions

### DIFF
--- a/dcos/httpclient.go
+++ b/dcos/httpclient.go
@@ -53,7 +53,7 @@ func (t *DefaultTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 	req2.Header.Set("User-Agent", userAgent)
 
-	if t.Logger != nil && os.Getenv("DCOS_DEBUG") != "" {
+	if t.Logger != nil && t.Logger.Level >= logrus.DebugLevel {
 		reqDump, err := httputil.DumpRequestOut(req2, true)
 		if err != nil {
 			t.Logger.Debugf("Couldn't dump request: %s", err)
@@ -64,7 +64,7 @@ func (t *DefaultTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	resp, err := t.base().RoundTrip(req2)
 
-	if err == nil && t.Logger != nil && os.Getenv("DCOS_DEBUG") != "" {
+	if err == nil && t.Logger != nil && t.Logger.Level >= logrus.DebugLevel {
 		respDump, err := httputil.DumpResponse(resp, true)
 		if err != nil {
 			t.Logger.Debugf("Couldn't dump response: %s", err)

--- a/dcos/httpclient.go
+++ b/dcos/httpclient.go
@@ -27,7 +27,7 @@ const (
 	defaultTransportMaxIdleConns = 30
 )
 
-// DefaultTransport is a http.RoundTripper that adds authentication based on Config
+// DefaultTransport is a http.RoundTripper that adds authentication based on Config.
 type DefaultTransport struct {
 	Config    *Config
 	Base      http.RoundTripper
@@ -42,7 +42,7 @@ func (t *DefaultTransport) base() http.RoundTripper {
 	return http.DefaultTransport
 }
 
-// RoundTrip authorizes requests to DC/OS by adding dcos_acs_token to Authorization header
+// RoundTrip authorizes requests to DC/OS by adding dcos_acs_token to Authorization header.
 func (t *DefaultTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// meet the requirements of RoundTripper and only modify a copy
 	req2 := cloneRequest(req)
@@ -141,14 +141,14 @@ func NewDefaultTransport(config *Config) *DefaultTransport {
 	}
 }
 
-// NewHTTPClient provides a http.Client able to communicate to dcos in an authenticated way
+// NewHTTPClient provides a http.Client able to communicate to dcos in an authenticated way.
 func NewHTTPClient(config *Config) *http.Client {
 	return &http.Client{
 		Transport: NewDefaultTransport(config),
 	}
 }
 
-// AddTransportHTTPClient adds dcos.DefaultTransport to http.Client to add dcos authentication
+// AddTransportHTTPClient adds dcos.DefaultTransport to http.Client to add dcos authentication.
 func AddTransportHTTPClient(client *http.Client, config *Config) *http.Client {
 	transport := DefaultTransport{
 		Config: config,

--- a/dcos/httpclient_test.go
+++ b/dcos/httpclient_test.go
@@ -53,3 +53,19 @@ func TestDefaultHTTPClientAuth(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 401, respDflt.StatusCode, "expect a forbidden state with http.DefaultClient")
 }
+
+func TestDefaultHTTPClientUserAgent(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "dcos-cli/0.7.1 linux", r.Header.Get("User-Agent"))
+	}))
+	defer s.Close()
+
+	transport := NewDefaultTransport(NewConfig(nil))
+	transport.UserAgent = "dcos-cli/0.7.1 linux"
+
+	httpClient := &http.Client{Transport: transport}
+
+	resp, err := httpClient.Get(s.URL)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+}


### PR DESCRIPTION
This PR addresses a few regressions we've noticed in the CLI after switching to client-go.

- Support passing a custom User-Agent
- Allow custom loggers
- Only dump textual bodies

https://jira.mesosphere.com/browse/DCOS-56241