### PR TITLE
Return a pointer to http.Client

### DIFF
--- a/dcos/client.go
+++ b/dcos/client.go
@@ -112,7 +112,7 @@ func (a *APIClient) CurrentDCOSConfig() Config {
 
 // HTTPClient returns a http.Client which does authenticated requests to DC/OS
 func (a *APIClient) HTTPClient() *http.Client {
-	return NewHTTPClient(a.dcosConfig)
+	return a.cfg.HTTPClient
 }
 
 func atoi(in string) (int, error) {

--- a/templates/client.mustache
+++ b/templates/client.mustache
@@ -103,7 +103,7 @@ func (a *APIClient) CurrentDCOSConfig() Config {
 
 // HTTPClient returns a http.Client which does authenticated requests to DC/OS
 func (a *APIClient) HTTPClient() *http.Client {
-	return NewHTTPClient(a.dcosConfig)
+	return a.cfg.HTTPClient
 }
 
 func atoi(in string) (int, error) {


### PR DESCRIPTION
Currently there is no way to create a DC/OS client with a custom User-Agent. Returning a pointer to the HTTP client allows to update the UserAgent field in the Transport.

We should probably revisit the API of this package at some point to make it more easily customizable.